### PR TITLE
Add frontend docker-compose service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,4 @@
 1. Распакуйте архив.
 2. Перейдите в папку opora-gpt.
 3. Запустите `docker compose -p oporagpt up --build`.
-4. В новом терминале: `cd frontend`, `npm install`, `npm run dev`.
-5. Откройте `http://localhost:5173`.
+4. Откройте `http://localhost:5173` для работы с интерфейсом.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,12 @@ services:
       POSTGRES_DB: oporagpt
     volumes:
       - pgdata:/var/lib/postgresql/data
+  frontend:
+    build:
+      context: ./frontend
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend
 volumes:
   pgdata:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json .
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
## Summary
- containerize frontend with a new Dockerfile
- run frontend via docker-compose
- update launch instructions in README

## Testing
- `npm install`
- `npm run build`
- `apt-get update`

------
https://chatgpt.com/codex/tasks/task_e_687665d5f0948333b3793c38d2ca726d